### PR TITLE
Fix usage deserialization

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -64,7 +64,7 @@ func TestEmbedRequiredArgsResponse(t *testing.T) {
 				},
 			},
 			Model: req.Model,
-			Useage: voyageai.UsageObject{
+			Usage: voyageai.UsageObject{
 				TotalTokens: 10,
 			},
 		}
@@ -148,7 +148,7 @@ func TestEmbedCustomArgsResponse(t *testing.T) {
 				},
 			},
 			Model: req.Model,
-			Useage: voyageai.UsageObject{
+			Usage: voyageai.UsageObject{
 				TotalTokens: 10,
 			},
 		}
@@ -222,7 +222,7 @@ func TestRerankRequiredArgsResponse(t *testing.T) {
 				},
 			},
 			Model: req.Model,
-			Useage: voyageai.UsageObject{
+			Usage: voyageai.UsageObject{
 				TotalTokens: 10,
 			},
 		}
@@ -299,7 +299,7 @@ func TestRerankCustomArgsResponse(t *testing.T) {
 				},
 			},
 			Model: req.Model,
-			Useage: voyageai.UsageObject{
+			Usage: voyageai.UsageObject{
 				TotalTokens: 10,
 			},
 		}
@@ -412,7 +412,7 @@ func TestMultimodalRequiredArgsRequest(t *testing.T) {
 				},
 			},
 			Model: req.Model,
-			Useage: voyageai.UsageObject{
+			Usage: voyageai.UsageObject{
 				TotalTokens: 10,
 			},
 		}
@@ -516,7 +516,7 @@ func TestMultimodalRequiredCustomRequest(t *testing.T) {
 				},
 			},
 			Model: req.Model,
-			Useage: voyageai.UsageObject{
+			Usage: voyageai.UsageObject{
 				TotalTokens: 10,
 			},
 		}
@@ -607,7 +607,7 @@ func TestMaxRetries(t *testing.T) {
 				},
 			},
 			Model: req.Model,
-			Useage: voyageai.UsageObject{
+			Usage: voyageai.UsageObject{
 				TotalTokens: 10,
 			},
 		}

--- a/types.go
+++ b/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 // A list of models supported by the Voyage AI API.
-type Model string
+type Model = string
 
 const (
 	ModelVoyage3Large   Model = "voyage-3-large"
@@ -24,7 +24,7 @@ const (
 )
 
 // OutputDimension represents the dimension size for embedding outputs.
-type OutputDimension int
+type OutputDimension = int
 
 const (
 	OutputDimension256  OutputDimension = 256
@@ -71,7 +71,7 @@ type EmbeddingObject struct {
 	Index     int       `json:"index"`     // An integer representing the index of the embedding within the list of embeddings.
 }
 
-// Contains details about system useage.
+// Contains details about system usage.
 type UsageObject struct {
 	TotalTokens int  `json:"total_tokens"`           // The total number of tokens used for computing the embeddings.
 	ImagePixels *int `json:"image_pixels,omitempty"` // The total number of image pixels in the list of inputs.
@@ -83,7 +83,7 @@ type EmbeddingResponse struct {
 	Object string            `json:"object"` // The object type, which is always "list".
 	Data   []EmbeddingObject `json:"data"`   // An array of embedding objects.
 	Model  string            `json:"model"`  // Name of the model.
-	Useage UsageObject       `json:"useage"` // An object containing useage details
+	Usage  UsageObject       `json:"usage"`  // An object containing usage details
 }
 
 type text string
@@ -256,5 +256,5 @@ type RerankResponse struct {
 	Object string         `json:"object"` // The object type, which is always "list".
 	Data   []RerankObject `json:"data"`   // An array of the reranking results, sorted by the descending order of relevance scores.
 	Model  string         `json:"model"`  // Name of the model.
-	Useage UsageObject    `json:"useage"` // An object containing useage details
+	Usage  UsageObject    `json:"usage"`  // An object containing usage details
 }


### PR DESCRIPTION
The usage `json` type was spelled incorrectly. I fixed that.

Also, when I made the enums I make the types incorrectly (forced an unnecessary cast). That is fixed now.