### PR TITLE
Fix examples and add additional models

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -15,7 +15,7 @@ func main() {
 			"Embed this text please",
 			"And this as well",
 		},
-		"voyage-3-lite",
+		voyageai.ModelVoyage3Lite,
 		nil,
 	)
 
@@ -23,7 +23,8 @@ func main() {
 		fmt.Printf("Could not get embedding: %s", err.Error())
 	}
 
-	fmt.Printf("%v\n", embeddings.Data[0].Embedding[0:5])
+	fmt.Printf("Embeddings (First 5): %v\n", embeddings.Data[0].Embedding[0:5])
+	fmt.Printf("Usage: %v\n", embeddings.Usage)
 
 	img, err := os.Open("./assets/gopher.png")
 	if err != nil {
@@ -45,20 +46,22 @@ func main() {
 		},
 	}
 
-	mEmbedding, err := vo.MultimodalEmbed(multimodalInput, "voyage-multimodal-3", nil)
+	mEmbedding, err := vo.MultimodalEmbed(multimodalInput, voyageai.ModelVoyageMultimodal3, nil)
 	if err != nil {
 		fmt.Printf("Could not get multimodal embedding: %s", err.Error())
 	}
-	fmt.Printf("%v\n", mEmbedding.Data[0].Embedding[0:5])
+	fmt.Printf("Multimodal Embeddings (First 5): %v\n", mEmbedding.Data[0].Embedding[0:5])
+	fmt.Printf("Usage: %v\n", mEmbedding.Usage)
 
 	reranking, err := vo.Rerank(
 		"This is an example query",
 		[]string{"this is a document", "this is also a document"},
-		"rerank-2-lite",
+		voyageai.ModelRerank2Lite,
 		nil,
 	)
 	if err != nil {
 		fmt.Printf("Could not get reranking results: %s", err.Error())
 	}
-	fmt.Printf("%v\n", reranking)
+	fmt.Printf("Reranking: %v\n", reranking.Data)
+	fmt.Printf("Usage: %v", reranking.Usage)
 }

--- a/types.go
+++ b/types.go
@@ -15,12 +15,15 @@ import (
 type Model = string
 
 const (
-	ModelVoyage3Large   Model = "voyage-3-large"
-	ModelVoyage3        Model = "voyage-3"
-	ModelVoyage3Lite    Model = "voyage-3-lite"
-	ModelVoyageCode3    Model = "voyage-code-3"
-	ModelVoyageFinance2 Model = "voyage-finance-2"
-	ModelVoyageLaw2     Model = "voyage-law-2"
+	ModelVoyage3Large      Model = "voyage-3-large"
+	ModelVoyage3           Model = "voyage-3"
+	ModelVoyage3Lite       Model = "voyage-3-lite"
+	ModelVoyageMultimodal3 Model = "voyage-multimodal-3"
+	ModelVoyageCode3       Model = "voyage-code-3"
+	ModelVoyageFinance2    Model = "voyage-finance-2"
+	ModelVoyageLaw2        Model = "voyage-law-2"
+	ModelRerank2           Model = "rerank-2"
+	ModelRerank2Lite       Model = "rerank-2-lite"
 )
 
 // OutputDimension represents the dimension size for embedding outputs.


### PR DESCRIPTION
This PR introduces a few small changes.

1. The examples were updated to print more useful information (imo) and to use the constants exported by the sdk for the models.
2. Additional models were added to the constant list of models in `types.go`