### PR TITLE
Client can handle results of different data types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt fmt-check test
+.PHONY: fmt fmt-check test integration_test
 
 fmt:
 	go fmt ./...
@@ -8,3 +8,6 @@ fmt-check:
 
 test:
 	go test -v ./...
+
+integration_test:
+	go test -v -tags=integration ./...

--- a/client.go
+++ b/client.go
@@ -142,15 +142,41 @@ func (c *VoyageClient) handleAPIRequest(reqBody any, respBody any, url string) e
 	return nil
 }
 
+func (c *VoyageClient) Embed(texts []string, model string, opts *EmbeddingRequestOpts) (*EmbeddingResponse[float32], error) {
+	return embed[float32](c, texts, model, opts)
+}
+
+func (c *VoyageClient) EmbedInt8(texts []string, model string, opts *EmbeddingRequestOpts) (*EmbeddingResponse[int8], error) {
+	var _opts EmbeddingRequestOpts
+	if opts != nil {
+		_opts = *opts
+	}
+	if _opts.OutputDType == nil {
+		_opts.OutputDType = Opt("int8")
+	}
+	return embed[int8](c, texts, model, &_opts)
+}
+
+func (c *VoyageClient) EmbedUint8(texts []string, model string, opts *EmbeddingRequestOpts) (*EmbeddingResponse[uint8], error) {
+	var _opts EmbeddingRequestOpts
+	if opts != nil {
+		_opts = *opts
+	}
+	if _opts.OutputDType == nil {
+		_opts.OutputDType = Opt("uint8")
+	}
+	return embed[uint8](c, texts, model, &_opts)
+}
+
 // Returns a pointer to an [EmbeddingResponse] or an error if the request failed.
 //
 // Parameters:
 //   - texts - A list of texts as a list of strings, such as ["I like cats", "I also like dogs"]
 //   - model - Name of the model. Recommended options: voyage-3-large, voyage-3, voyage-3-lite, voyage-code-3, voyage-finance-2, voyage-law-2.
 //   - opts - optional parameters, see [EmbeddingRequestOpts]
-func (c *VoyageClient) Embed(texts []string, model string, opts *EmbeddingRequestOpts) (*EmbeddingResponse, error) {
+func embed[T float32 | uint8 | int8](c *VoyageClient, texts []string, model string, opts *EmbeddingRequestOpts) (*EmbeddingResponse[T], error) {
 	var reqBody EmbeddingRequest
-	var respBody EmbeddingResponse
+	var respBody EmbeddingResponse[T]
 	if opts != nil {
 		reqBody = EmbeddingRequest{
 			Input:           texts,
@@ -180,9 +206,9 @@ func (c *VoyageClient) Embed(texts []string, model string, opts *EmbeddingReques
 //   - opts - Optional parameters, see [MultimodalRequestOpts]
 //
 // [Voyage AI docs]: https://docs.voyageai.com/docs/multimodal-embeddings
-func (c *VoyageClient) MultimodalEmbed(inputs []MultimodalContent, model string, opts *MultimodalRequestOpts) (*EmbeddingResponse, error) {
+func (c *VoyageClient) MultimodalEmbed(inputs []MultimodalContent, model string, opts *MultimodalRequestOpts) (*EmbeddingResponse[float32], error) {
 	var reqBody MultimodalRequest
-	var respBody EmbeddingResponse
+	var respBody EmbeddingResponse[float32]
 	if opts != nil {
 		reqBody = MultimodalRequest{
 			Inputs:        inputs,

--- a/client_test.go
+++ b/client_test.go
@@ -49,17 +49,17 @@ func TestEmbedRequiredArgsResponse(t *testing.T) {
 			t.Errorf("Expected non-empty value for 'Model'")
 		}
 
-		resp := voyageai.EmbeddingResponse{
+		resp := voyageai.EmbeddingResponse[float32]{
 			Object: "list",
-			Data: []voyageai.EmbeddingObject{
+			Data: []voyageai.EmbeddingObject[float32]{
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.1, 0.2, 0.3},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.1, 0.2, 0.3}},
 					Index:     0,
 				},
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.4, 0.5, 0.6},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.4, 0.5, 0.6}},
 					Index:     1,
 				},
 			},
@@ -133,17 +133,17 @@ func TestEmbedCustomArgsResponse(t *testing.T) {
 			t.Errorf("Expected non-nil value for 'OutputDimension'")
 		}
 
-		resp := voyageai.EmbeddingResponse{
+		resp := voyageai.EmbeddingResponse[float32]{
 			Object: "list",
-			Data: []voyageai.EmbeddingObject{
+			Data: []voyageai.EmbeddingObject[float32]{
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.1, 0.2, 0.3},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.1, 0.2, 0.3}},
 					Index:     0,
 				},
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.4, 0.5, 0.6},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.4, 0.5, 0.6}},
 					Index:     1,
 				},
 			},
@@ -397,17 +397,17 @@ func TestMultimodalRequiredArgsRequest(t *testing.T) {
 			t.Error("Invalid data url")
 		}
 
-		resp := voyageai.EmbeddingResponse{
+		resp := voyageai.EmbeddingResponse[float32]{
 			Object: "list",
-			Data: []voyageai.EmbeddingObject{
+			Data: []voyageai.EmbeddingObject[float32]{
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.1, 0.2, 0.3},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.1, 0.2, 0.3}},
 					Index:     0,
 				},
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.4, 0.5, 0.6},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.4, 0.5, 0.6}},
 					Index:     1,
 				},
 			},
@@ -501,17 +501,17 @@ func TestMultimodalRequiredCustomRequest(t *testing.T) {
 			t.Error("Invalid data url")
 		}
 
-		resp := voyageai.EmbeddingResponse{
+		resp := voyageai.EmbeddingResponse[float32]{
 			Object: "list",
-			Data: []voyageai.EmbeddingObject{
+			Data: []voyageai.EmbeddingObject[float32]{
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.1, 0.2, 0.3},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.1, 0.2, 0.3}},
 					Index:     0,
 				},
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.4, 0.5, 0.6},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.4, 0.5, 0.6}},
 					Index:     1,
 				},
 			},
@@ -592,17 +592,17 @@ func TestMaxRetries(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Invalid request body")
 		}
-		resp := voyageai.EmbeddingResponse{
+		resp := voyageai.EmbeddingResponse[float32]{
 			Object: "list",
-			Data: []voyageai.EmbeddingObject{
+			Data: []voyageai.EmbeddingObject[float32]{
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.1, 0.2, 0.3},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.1, 0.2, 0.3}},
 					Index:     0,
 				},
 				{
 					Object:    "embedding",
-					Embedding: []float32{0.4, 0.5, 0.6},
+					Embedding: voyageai.Embedding[float32]{AsNumeric: []float32{0.4, 0.5, 0.6}},
 					Index:     1,
 				},
 			},

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -23,7 +23,7 @@ func main() {
 		fmt.Printf("Could not get embedding: %s", err.Error())
 	}
 
-	fmt.Printf("Embeddings (First 5): %v\n", embeddings.Data[0].Embedding[0:5])
+	fmt.Printf("Embeddings (First 5): %v\n", embeddings.Data[0].Embedding.AsNumeric[0:5])
 	fmt.Printf("Usage: %v\n", embeddings.Usage)
 
 	img, err := os.Open("./assets/gopher.png")
@@ -50,7 +50,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("Could not get multimodal embedding: %s", err.Error())
 	}
-	fmt.Printf("Multimodal Embeddings (First 5): %v\n", mEmbedding.Data[0].Embedding[0:5])
+	fmt.Printf("Multimodal Embeddings (First 5): %v\n", mEmbedding.Data[0].Embedding.AsNumeric[0:5])
 	fmt.Printf("Usage: %v\n", mEmbedding.Usage)
 
 	reranking, err := vo.Rerank(

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,249 @@
+//go:build integration
+// +build integration
+
+package voyageai
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEmbeddingWithDifferentEncodings(t *testing.T) {
+	// Create client using environment variable
+	client := NewClient(nil)
+
+	// Test texts to embed
+	texts := []string{"This is a test sentence for embedding."}
+	model := "voyage-3-large"
+
+	// First request with default encoding
+	defaultResp, err := client.Embed(texts, model, nil)
+	if err != nil {
+		t.Fatalf("Failed to get embeddings with default encoding: %v", err)
+	}
+
+	// Second request with base64 encoding
+	base64Resp, err := client.Embed(texts, model, &EmbeddingRequestOpts{
+		EncodingFormat: Opt("base64"),
+	})
+	if err != nil {
+		t.Fatalf("Failed to get embeddings with base64 encoding: %v", err)
+	}
+
+	// Verify both responses have the same model
+	if defaultResp.Model != base64Resp.Model {
+		t.Errorf("Model mismatch: default=%s, base64=%s", defaultResp.Model, base64Resp.Model)
+	}
+
+	// Verify both responses have the same number of embeddings
+	if len(defaultResp.Data) != len(base64Resp.Data) {
+		t.Errorf("Embedding count mismatch: default=%d, base64=%d",
+			len(defaultResp.Data), len(base64Resp.Data))
+	}
+
+	// Verify embeddings are equivalent
+	if len(defaultResp.Data) > 0 && len(base64Resp.Data) > 0 {
+		defaultEmbedding := defaultResp.Data[0].Embedding
+		base64Embedding := base64Resp.Data[0].Embedding
+
+		base64Slice, err := base64Embedding.ToSlice()
+		if err != nil {
+			t.Errorf("Failed to decode base64 embedding: %v", err)
+		}
+
+		if len(defaultEmbedding.AsNumeric) != len(base64Slice) {
+			t.Errorf("Embedding dimension mismatch: default=%d, base64=%d",
+				len(defaultEmbedding.AsNumeric), len(base64Slice))
+		} else {
+			// Compare actual values (should be the same regardless of encoding format)
+			for i := range defaultEmbedding.AsNumeric {
+				if !almostEqual(defaultEmbedding.AsNumeric[i], base64Slice[i], 1e-6) {
+					t.Errorf("Embedding value mismatch at index %d: default=%f, base64=%f",
+						i, defaultEmbedding.AsNumeric[i], base64Slice[i])
+				}
+			}
+		}
+	}
+
+	// Make sure the responses are equivalent when comparing their data structures
+	// (excluding the actual embedding values which we already compared)
+	defaultRespCopy := *defaultResp
+	base64RespCopy := *base64Resp
+
+	// Set embeddings to nil so we can compare the rest of the structure
+	if len(defaultRespCopy.Data) > 0 {
+		defaultRespCopy.Data[0].Embedding = Embedding[float32]{}
+	}
+	if len(base64RespCopy.Data) > 0 {
+		base64RespCopy.Data[0].Embedding = Embedding[float32]{}
+	}
+
+	if !reflect.DeepEqual(defaultRespCopy, base64RespCopy) {
+		t.Errorf("Response structure mismatch after excluding embeddings")
+	}
+}
+
+func TestEmbedInt8WithDifferentEncodings(t *testing.T) {
+	// Create client using environment variable
+	client := NewClient(nil)
+
+	// Test texts to embed
+	texts := []string{"This is a test sentence for int8 embedding."}
+	model := "voyage-3-large"
+
+	// First request with default encoding
+	defaultResp, err := client.EmbedInt8(texts, model, &EmbeddingRequestOpts{
+		OutputDType: Opt("int8"),
+	})
+	if err != nil {
+		t.Fatalf("Failed to get int8 embeddings with default encoding: %v", err)
+	}
+
+	// Second request with base64 encoding
+	base64Resp, err := client.EmbedInt8(texts, model, &EmbeddingRequestOpts{
+		OutputDType:    Opt("int8"),
+		EncodingFormat: Opt("base64"),
+	})
+	if err != nil {
+		t.Fatalf("Failed to get int8 embeddings with base64 encoding: %v", err)
+	}
+
+	// Verify both responses have the same model
+	if defaultResp.Model != base64Resp.Model {
+		t.Errorf("Model mismatch: default=%s, base64=%s", defaultResp.Model, base64Resp.Model)
+	}
+
+	// Verify both responses have the same number of embeddings
+	if len(defaultResp.Data) != len(base64Resp.Data) {
+		t.Errorf("Embedding count mismatch: default=%d, base64=%d",
+			len(defaultResp.Data), len(base64Resp.Data))
+	}
+
+	// Verify embeddings are equivalent
+	if len(defaultResp.Data) > 0 && len(base64Resp.Data) > 0 {
+		defaultEmbedding := defaultResp.Data[0].Embedding
+		base64Embedding := base64Resp.Data[0].Embedding
+
+		base64Slice, err := base64Embedding.ToSlice()
+		if err != nil {
+			t.Errorf("Failed to decode base64 embedding: %v", err)
+		}
+
+		if len(defaultEmbedding.AsNumeric) != len(base64Slice) {
+			t.Errorf("Embedding dimension mismatch: default=%d, base64=%d",
+				len(defaultEmbedding.AsNumeric), len(base64Slice))
+		} else {
+			// Compare actual values (should be the same regardless of encoding format)
+			for i := range defaultEmbedding.AsNumeric {
+				if defaultEmbedding.AsNumeric[i] != base64Slice[i] {
+					t.Errorf("Embedding value mismatch at index %d: default=%d, base64=%d",
+						i, defaultEmbedding.AsNumeric[i], base64Slice[i])
+				}
+			}
+		}
+	}
+
+	// Make sure the responses are equivalent when comparing their data structures
+	// (excluding the actual embedding values which we already compared)
+	defaultRespCopy := *defaultResp
+	base64RespCopy := *base64Resp
+
+	// Set embeddings to nil so we can compare the rest of the structure
+	if len(defaultRespCopy.Data) > 0 {
+		defaultRespCopy.Data[0].Embedding = Embedding[int8]{}
+	}
+	if len(base64RespCopy.Data) > 0 {
+		base64RespCopy.Data[0].Embedding = Embedding[int8]{}
+	}
+
+	if !reflect.DeepEqual(defaultRespCopy, base64RespCopy) {
+		t.Errorf("Response structure mismatch after excluding embeddings")
+	}
+}
+
+func TestEmbedUint8WithDifferentEncodings(t *testing.T) {
+	// Create client using environment variable
+	client := NewClient(nil)
+
+	// Test texts to embed
+	texts := []string{"This is a test sentence for uint8 embedding."}
+	model := "voyage-3-large"
+
+	// First request with default encoding
+	defaultResp, err := client.EmbedUint8(texts, model, &EmbeddingRequestOpts{
+		OutputDType: Opt("uint8"),
+	})
+	if err != nil {
+		t.Fatalf("Failed to get uint8 embeddings with default encoding: %v", err)
+	}
+
+	// Second request with base64 encoding
+	base64Resp, err := client.EmbedUint8(texts, model, &EmbeddingRequestOpts{
+		OutputDType:    Opt("uint8"),
+		EncodingFormat: Opt("base64"),
+	})
+	if err != nil {
+		t.Fatalf("Failed to get uint8 embeddings with base64 encoding: %v", err)
+	}
+
+	// Verify both responses have the same model
+	if defaultResp.Model != base64Resp.Model {
+		t.Errorf("Model mismatch: default=%s, base64=%s", defaultResp.Model, base64Resp.Model)
+	}
+
+	// Verify both responses have the same number of embeddings
+	if len(defaultResp.Data) != len(base64Resp.Data) {
+		t.Errorf("Embedding count mismatch: default=%d, base64=%d",
+			len(defaultResp.Data), len(base64Resp.Data))
+	}
+
+	// Verify embeddings are equivalent
+	if len(defaultResp.Data) > 0 && len(base64Resp.Data) > 0 {
+		defaultEmbedding := defaultResp.Data[0].Embedding
+		base64Embedding := base64Resp.Data[0].Embedding
+
+		base64Slice, err := base64Embedding.ToSlice()
+		if err != nil {
+			t.Errorf("Failed to decode base64 embedding: %v", err)
+		}
+
+		if len(defaultEmbedding.AsNumeric) != len(base64Slice) {
+			t.Errorf("Embedding dimension mismatch: default=%d, base64=%d",
+				len(defaultEmbedding.AsNumeric), len(base64Slice))
+		} else {
+			// Compare actual values (should be the same regardless of encoding format)
+			for i := range defaultEmbedding.AsNumeric {
+				if defaultEmbedding.AsNumeric[i] != base64Slice[i] {
+					t.Errorf("Embedding value mismatch at index %d: default=%d, base64=%d",
+						i, defaultEmbedding.AsNumeric[i], base64Slice[i])
+				}
+			}
+		}
+	}
+
+	// Make sure the responses are equivalent when comparing their data structures
+	// (excluding the actual embedding values which we already compared)
+	defaultRespCopy := *defaultResp
+	base64RespCopy := *base64Resp
+
+	// Set embeddings to nil so we can compare the rest of the structure
+	if len(defaultRespCopy.Data) > 0 {
+		defaultRespCopy.Data[0].Embedding = Embedding[uint8]{}
+	}
+	if len(base64RespCopy.Data) > 0 {
+		base64RespCopy.Data[0].Embedding = Embedding[uint8]{}
+	}
+
+	if !reflect.DeepEqual(defaultRespCopy, base64RespCopy) {
+		t.Errorf("Response structure mismatch after excluding embeddings")
+	}
+}
+
+// Helper function to compare float values with tolerance
+func almostEqual(a, b float32, tolerance float32) bool {
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= tolerance
+}


### PR DESCRIPTION
To allow complete use of Voyage's API, the Embedding Response object is made generic (limited to float32, int8, uint8).

Additionally, the Embedding object is made into a union type to allow it to comprehend default encoding (array of values) and base64 encoding, which returns a string value. For the latter case we provide a method AsSlice() that returns the normal encoding if present, else decodes the base64 string and converts to a slice when that is what was returned by the model.

There are a couple of minor breaking changes:

1. Since the response is made generic, existing variables that declare a type may need to be updated
2. The numeric slice now needs to be retrieved as `AsNumeric` from the embedding object.