### PR TITLE
Add support for new Voyage AI 3.5 models

### DIFF
--- a/client.go
+++ b/client.go
@@ -146,7 +146,7 @@ func (c *VoyageClient) handleAPIRequest(reqBody any, respBody any, url string) e
 //
 // Parameters:
 //   - texts - A list of texts as a list of strings, such as ["I like cats", "I also like dogs"]
-//   - model - Name of the model. Recommended options: voyage-3-large, voyage-3, voyage-3-lite, voyage-code-3, voyage-finance-2, voyage-law-2.
+//   - model - Name of the model. Recommended options: voyage-3-large, voyage-3.5, voyage-3.5-lite, voyage-code-3, voyage-finance-2, voyage-law-2.
 //   - opts - optional parameters, see [EmbeddingRequestOpts]
 func (c *VoyageClient) Embed(texts []string, model string, opts *EmbeddingRequestOpts) (*EmbeddingResponse, error) {
 	var reqBody EmbeddingRequest
@@ -176,7 +176,7 @@ func (c *VoyageClient) Embed(texts []string, model string, opts *EmbeddingReques
 //
 // Parameters:
 //   - inputs - A list of multimodal inputs to be vectorized. See the "[Voyage AI docs]" for info on constraints.
-//   - model - Name of the model. Recommended options: voyage-3-large, voyage-3, voyage-3-lite, voyage-code-3, voyage-finance-2, voyage-law-2.
+//   - model - Name of the model. Recommended options: voyage-3-large, voyage-3.5, voyage-3.5-lite, voyage-code-3, voyage-finance-2, voyage-law-2.
 //   - opts - Optional parameters, see [MultimodalRequestOpts]
 //
 // [Voyage AI docs]: https://docs.voyageai.com/docs/multimodal-embeddings

--- a/types.go
+++ b/types.go
@@ -18,6 +18,8 @@ const (
 	ModelVoyage3Large      Model = "voyage-3-large"
 	ModelVoyage3           Model = "voyage-3"
 	ModelVoyage3Lite       Model = "voyage-3-lite"
+	ModelVoyage35          Model = "voyage-3.5"
+	ModelVoyage35Lite      Model = "voyage-3.5-lite"
 	ModelVoyageMultimodal3 Model = "voyage-multimodal-3"
 	ModelVoyageCode3       Model = "voyage-code-3"
 	ModelVoyageFinance2    Model = "voyage-finance-2"
@@ -45,7 +47,7 @@ const (
 type EmbeddingRequest struct {
 	// A list of strings to be embedded.
 	Input []string `json:"input"`
-	// Name of the model. Recommended options: voyage-3-large, voyage-3, voyage-3-lite, voyage-code-3, voyage-finance-2, voyage-law-2.
+	// Name of the model. Recommended options: voyage-3-large, voyage-3.5, voyage-3.5-lite, voyage-code-3, voyage-finance-2, voyage-law-2.
 	Model string `json:"model"`
 	// Type of the input text. Defaults to null. Other options: query, document.
 	InputType *string `json:"input_type,omitempty"`


### PR DESCRIPTION
This PR adds support for the new Voyage AI 3.5 models that were recently announced. The changes include:

## New Model Constants Added

- `ModelVoyage35` = "voyage-3.5"  
- `ModelVoyage35Lite` = "voyage-3.5-lite"

These constants are now available alongside the existing model constants and can be used directly in embedding and multimodal embedding requests:

```go
import "github.com/austinfhunter/voyageai"

client := voyageai.NewClient(nil)

// Use the new voyage-3.5 model
embeddings, err := client.Embed(
    []string{"Example text"},
    voyageai.ModelVoyage35,
    nil,
)

// Use the new voyage-3.5-lite model  
embeddings, err := client.Embed(
    []string{"Example text"},
    voyageai.ModelVoyage35Lite,
    nil,
)
```

## Documentation Updates

Updated the recommended model lists in function documentation to reflect the current Voyage AI API recommendations:
- `Embed()` function documentation
- `MultimodalEmbed()` function documentation  
- `EmbeddingRequest` struct field documentation

The recommended models list now includes: `voyage-3-large`, `voyage-3.5`, `voyage-3.5-lite`, `voyage-code-3`, `voyage-finance-2`, `voyage-law-2`. Based on https://docs.voyageai.com/reference/embeddings-api

## Backward Compatibility

All existing model constants remain unchanged, ensuring full backward compatibility. No breaking changes were introduced.

This update aligns the Go client library with the latest Voyage AI API model offerings as documented at https://docs.voyageai.com/docs/embeddings#model-choices.